### PR TITLE
Fix compatibility with BepInEx 6.0-be IL2CPP

### DIFF
--- a/Plugin.cs
+++ b/Plugin.cs
@@ -1,6 +1,6 @@
 ﻿using BepInEx;
 #if !BEPIN_5
-using BepInEx.IL2CPP;
+using BepInEx.Unity.IL2CPP;
 #endif
 using BepInEx.Configuration;
 using HarmonyLib;

--- a/TaikoModStuff-Bepin6.csproj
+++ b/TaikoModStuff-Bepin6.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <AssemblyName>TaikoModStuff</AssemblyName>
     <Description>My first plugin</Description>
     <Version>1.3.1</Version>
@@ -15,8 +15,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="BepInEx.IL2CPP" Version="6.0.0-*" IncludeAssets="compile" />
     <PackageReference Include="BepInEx.PluginInfoProps" Version="1.*" />
+    <PackageReference Include="BepInEx.Unity.IL2CPP" Version="6.0.0-be.663" />
     <PackageReference Include="UnityEngine.Modules" Version="2020.3.19" IncludeAssets="compile" />
   </ItemGroup>
   

--- a/TaikoModStuff-Bepin6.csproj
+++ b/TaikoModStuff-Bepin6.csproj
@@ -26,15 +26,15 @@
   
   <ItemGroup>
     <Reference Include="Assembly-CSharp">
-      <HintPath>lib\Assembly-CSharp.dll</HintPath>
+      <HintPath>C:\XboxGames\T Tablet\Content\BepInEx\interop\Assembly-CSharp.dll</HintPath>
 	  <Private>False</Private>
     </Reference>
     <Reference Include="Il2Cppmscorlib">
-      <HintPath>lib\Il2Cppmscorlib.dll</HintPath>
+      <HintPath>C:\XboxGames\T Tablet\Content\BepInEx\interop\Il2Cppmscorlib.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.CoreModule">
-      <HintPath>lib\UnityEngine.CoreModule.dll</HintPath>
+      <HintPath>C:\XboxGames\T Tablet\Content\BepInEx\interop\UnityEngine.CoreModule.dll</HintPath>
 	  <Private>False</Private>
     </Reference>
   </ItemGroup>

--- a/TaikoModStuff-Bepin6.csproj
+++ b/TaikoModStuff-Bepin6.csproj
@@ -26,15 +26,15 @@
   
   <ItemGroup>
     <Reference Include="Assembly-CSharp">
-      <HintPath>C:\XboxGames\T Tablet\Content\BepInEx\interop\Assembly-CSharp.dll</HintPath>
+      <HintPath>lib\Assembly-CSharp.dll</HintPath>
 	  <Private>False</Private>
     </Reference>
     <Reference Include="Il2Cppmscorlib">
-      <HintPath>C:\XboxGames\T Tablet\Content\BepInEx\interop\Il2Cppmscorlib.dll</HintPath>
+      <HintPath>lib\Il2Cppmscorlib.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.CoreModule">
-      <HintPath>C:\XboxGames\T Tablet\Content\BepInEx\interop\UnityEngine.CoreModule.dll</HintPath>
+      <HintPath>lib\UnityEngine.CoreModule.dll</HintPath>
 	  <Private>False</Private>
     </Reference>
   </ItemGroup>


### PR DESCRIPTION
Tested working with BepInEx-Unity.IL2CPP-win-x64-6.0.0-be.663+5796f53 and the latest version of the game (1.9.0.0)

I was unsure what you had in your lib folder; I changed the hint path directly to the BepInEx folder so it would build for me.

Fixes #10 